### PR TITLE
Resrc abstraction

### DIFF
--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -36,6 +36,8 @@
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
+
+
 typedef struct zhash_t resources;
 typedef struct zlist_t resource_list;
 
@@ -94,7 +96,6 @@ void resrc_id_list_destroy (resource_list_t * resrc_ids_in)
     }
 }
 
-<<<<<<< HEAD
 char* resrc_list_first(resource_list_t * rl)
 {
     return zlist_first((zlist_t*)rl);
@@ -103,6 +104,11 @@ char* resrc_list_first(resource_list_t * rl)
 char* resrc_list_next(resource_list_t * rl)
 {
     return zlist_next((zlist_t*)rl);
+}
+
+size_t resrc_list_size(resource_list_t * rl)
+{
+    return zlist_size((zlist_t*)rl);
 }
 
 resrc_t* resrc_new_resource (const char *type, const char *name, int64_t id,

--- a/resrc/resrc.c
+++ b/resrc/resrc.c
@@ -36,6 +36,9 @@
 #include "src/common/libutil/shortjson.h"
 #include "src/common/libutil/xzmalloc.h"
 
+typedef struct zhash_t resources;
+typedef struct zlist_t resource_list;
+
 typedef struct {
     char *type;
     int64_t items;
@@ -72,8 +75,14 @@ void jobid_destroy (void *object)
 	free (tmp);
 }
 
-void resrc_id_list_destroy (zlist_t *resrc_ids)
+resource_list_t * resrc_new_id_list()
 {
+    return (resource_list_t *) zlist_new();
+}
+
+void resrc_id_list_destroy (resource_list_t * resrc_ids_in)
+{
+    zlist_t * resrc_ids = (zlist_t*)resrc_ids_in;
     if (resrc_ids) {
         char *resrc_id = zlist_first (resrc_ids);
         while (resrc_id) {
@@ -83,6 +92,16 @@ void resrc_id_list_destroy (zlist_t *resrc_ids)
         }
         zlist_destroy (&resrc_ids);
     }
+}
+
+char* resrc_list_first(resource_list_t * rl)
+{
+    return zlist_first((zlist_t*)rl);
+}
+
+char* resrc_list_next(resource_list_t * rl)
+{
+    return zlist_next((zlist_t*)rl);
 }
 
 resource_t* resrc_new_resource (const char *type, const char *name, int64_t id,
@@ -195,7 +214,7 @@ static void resrc_add_resource(zhash_t *resrcs, const char *parent,
     }
 }
 
-zhash_t *resrc_generate_resources (const char *path, char* resource)
+resources_t *resrc_generate_resources (const char *path, char* resource)
 {
     const char *name = NULL;
     json_object *o = NULL;
@@ -220,16 +239,21 @@ zhash_t *resrc_generate_resources (const char *path, char* resource)
     rdl_destroy (rdl);
     rdllib_close (l);
 ret:
-    return resrcs;
+    return (resources_t *)resrcs;
 }
 
-void resrc_print_resources (zhash_t *resrcs)
+void resrc_destroy_resources (resources_t **resources)
+{
+    zhash_destroy((zhash_t**)resources);
+}
+
+void resrc_print_resources (resources_t *resrcs)
 {
     char *resrc_id;
     char out[40];
     int64_t *id_ptr;
     resource_t *resrc;
-    zlist_t *resrc_ids = zhash_keys (resrcs);
+    zlist_t *resrc_ids = zhash_keys ((zhash_t*)resrcs);
 
     if (!resrcs) {
         return;
@@ -237,7 +261,7 @@ void resrc_print_resources (zhash_t *resrcs)
 
     resrc_id = zlist_first (resrc_ids);
     while (resrc_id) {
-        resrc = zhash_lookup (resrcs, resrc_id);
+        resrc = zhash_lookup ((zhash_t*)resrcs, resrc_id);
         if (resrc) {
             uuid_unparse (resrc->uuid, out);
             printf ("resrc type:%s, name:%s, id:%ld, state:%d, uuid: %s",
@@ -262,12 +286,14 @@ void resrc_print_resources (zhash_t *resrcs)
         }
         resrc_id = zlist_next (resrc_ids);
     }
-    resrc_id_list_destroy (resrc_ids);
+    zlist_destroy (&resrc_ids);
 }
 
-int resrc_find_resources (zhash_t *resrcs, zlist_t *found, const char *type,
+int resrc_find_resources (resources_t *resrcs_in, resource_list_t * found_in, const char *type,
                           bool available)
 {
+    zhash_t * resrcs = (zhash_t*)resrcs_in;
+    zlist_t * found = (zlist_t*)found_in;
     char *resrc_id;
     int nfound = 0;
     resource_t *resrc;
@@ -299,15 +325,17 @@ int resrc_find_resources (zhash_t *resrcs, zlist_t *found, const char *type,
             resrc_id = zlist_next (resrc_ids);
         }
     }
-    resrc_id_list_destroy (resrc_ids);
+    zlist_destroy (&resrc_ids);
 
 ret:
     return nfound;
 }
 
-int resrc_allocate_resources (zhash_t *resrcs, zlist_t *resrc_ids,
+int resrc_allocate_resources (resources_t *resrcs_in, resource_list_t * resrc_ids_in,
                                      int64_t job_id)
 {
+    zhash_t * resrcs = (zhash_t *)resrcs_in;
+    zlist_t * resrc_ids = (zlist_t*)resrc_ids_in;
     char *resrc_id;
     int64_t *id_ptr;
     resource_t *resrc;
@@ -331,9 +359,11 @@ ret:
     return rc;
 }
 
-int resrc_reserve_resources (zhash_t *resrcs, zlist_t *resrc_ids,
+int resrc_reserve_resources (resources_t *resrcs_in, resource_list_t * resrc_ids_in,
                                     int64_t job_id)
 {
+    zhash_t * resrcs = (zhash_t*)resrcs_in;
+    zlist_t * resrc_ids = (zlist_t*)resrc_ids_in;
     char *resrc_id;
     int64_t *id_ptr;
     resource_t *resrc;
@@ -358,8 +388,10 @@ ret:
     return rc;
 }
 
-json_object *resrc_serialize (zhash_t *resrcs, zlist_t *resrc_ids)
+json_object *resrc_serialize (resources_t *resrcs_in, resource_list_t * resrc_ids_in)
 {
+    zhash_t * resrcs = (zhash_t *)resrcs_in;
+    zlist_t * resrc_ids = (zlist_t*)resrc_ids_in;
     char *resrc_id;
     json_object *ja;
     json_object *o = NULL;
@@ -382,9 +414,11 @@ ret:
     return o;
 }
 
-int resrc_release_resources (zhash_t *resrcs, zlist_t *resrc_ids,
+int resrc_release_resources (resources_t *resrcs_in, resource_list_t * resrc_ids_in,
                              int64_t rel_job)
 {
+    zhash_t * resrcs = (zhash_t *)resrcs_in;
+    zlist_t * resrc_ids = (zlist_t*)resrc_ids_in;
     char *resrc_id;
     int64_t *id_ptr;
     resource_t *resrc;

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -11,6 +11,8 @@
 #include "src/common/liblsd/list.h"
 
 typedef struct resource resource_t;
+typedef struct resource_list resource_list_t;
+typedef struct resources resources_t;
 
 typedef enum {
     RESOURCE_INVALID,
@@ -34,9 +36,24 @@ char* resrc_type (resource_t *resrc);
 void jobid_destroy (void *object);
 
 /*
+ * Create a list of resource keys
+ */
+resource_list_t * resrc_new_id_list();
+
+/*
  * Destroy a list of resource keys
  */
-void resrc_id_list_destroy (zlist_t *resrc_ids);
+void resrc_id_list_destroy (resource_list_t * resrc_ids);
+
+/*
+ * Get the first element in the result list
+ */
+char* resrc_list_first(resource_list_t * rl);
+
+/*
+ * Get the next element in the resource id list
+ */
+char* resrc_list_next();
 
 /*
  * Create a new resource object
@@ -58,12 +75,17 @@ void resrc_resource_destroy (void *object);
  * Create a hash table of all resources described by a configuration
  * file
  */
-zhash_t *resrc_generate_resources (const char *path, char* resource);
+resources_t * resrc_generate_resources (const char *path, char* resource);
+
+/*
+ * De-allocate the resources handle
+ */
+void resrc_destroy_resources (resources_t * *resources);
 
 /*
  * Provide a listing to stdout of every resource in hash table
  */
-void resrc_print_resources (zhash_t *resrcs);
+void resrc_print_resources (resources_t * resrcs);
 
 /*
  * Find resources of the requested type
@@ -76,31 +98,31 @@ void resrc_print_resources (zhash_t *resrcs);
  *          found - any resources found are added to this list
  *
  */
-int resrc_find_resources (zhash_t *resrcs, zlist_t *found, const char *type,
+int resrc_find_resources (resources_t * resrcs, resource_list_t * found, const char *type,
                           bool available);
 
 /*
  * Allocate a set of resources to a job
  */
-int resrc_allocate_resources (zhash_t *resrcs, zlist_t *resrc_ids,
+int resrc_allocate_resources (resources_t * resrcs, resource_list_t * resrc_ids,
                               int64_t job_id);
 
 /*
  * Reserve a set of resources to a job
  */
-int resrc_reserve_resources (zhash_t *resrcs, zlist_t *resrc_ids,
+int resrc_reserve_resources (resources_t * resrcs, resource_list_t * resrc_ids,
                              int64_t job_id);
 
 /*
  * Create a json object containing the resources present in the input
  * list
  */
-json_object *resrc_serialize (zhash_t *resrcs, zlist_t *resrc_ids);
+json_object *resrc_serialize (resources_t * resrcs, resource_list_t * resrc_ids);
 
 /*
  * Remove a job allocation from a set of resources
  */
-int resrc_release_resources (zhash_t *resrcs, zlist_t *resrc_ids,
+int resrc_release_resources (resources_t * resrcs, resource_list_t * resrc_ids,
                              int64_t rel_job);
 
 

--- a/resrc/resrc.h
+++ b/resrc/resrc.h
@@ -56,6 +56,11 @@ char* resrc_list_first(resource_list_t * rl);
 char* resrc_list_next();
 
 /*
+ * Get the next element in the resource id list
+ */
+size_t resrc_list_size();
+
+/*
  * Create a new resource object
  */
 resrc_t* resrc_new_resource (const char *type, const char *name, int64_t id,

--- a/resrc/test/tresrc.c
+++ b/resrc/test/tresrc.c
@@ -10,42 +10,68 @@
 #include "src/common/libutil/jsonutil.h"
 #include "src/common/libutil/xzmalloc.h"
 
+#include <sys/time.h>
+#include <sys/types.h>
+
+static struct timeval start_time;
+
+void init_time() {
+              gettimeofday(&start_time, NULL);
+}
+
+u_int64_t get_time() {
+    struct timeval t;
+    gettimeofday(&t, NULL);
+    return (u_int64_t) (t.tv_sec - start_time.tv_sec) * 1000000
+        + (t.tv_usec - start_time.tv_usec);
+}
+
 int main (int argc, char** argv)
 {
     char *resrc_id;
     const char *filename = argv[1];
     int found = 0;
-    zhash_t *resrcs;
-    zlist_t *found_res = zlist_new ();
+    resources_t *resrcs;
+    resource_list_t *found_res = resrc_new_id_list ();
 
     if (filename == NULL || *filename == '\0')
         filename = getenv ("TESTRESRC_INPUT_FILE");
 
+    init_time();
     resrcs = resrc_generate_resources (filename, "default");
+    printf("resource generation took: %lf\n", ((double)get_time())/1000000);
     printf ("starting\n");
-    resrc_print_resources (resrcs);
+    /* resrc_print_resources (resrcs); */
+    init_time();
     found = resrc_find_resources (resrcs, found_res, "node", false);
     if (found) {
-        printf ("found\n");
-        resrc_id = zlist_first (found_res);
+        printf ("found %d nodes of %zu resources\n", found, zhash_size((zhash_t*)resrcs));
+        resrc_id = resrc_list_first (found_res);
         while (resrc_id) {
-            printf ("resrc_id %s\n", resrc_id);
-            resrc_id = zlist_next (found_res);
+            /* printf ("resrc_id %s\n", resrc_id); */
+            resrc_id = resrc_list_next (found_res);
         }
     }
+    printf("find and scan took: %lf\n", ((double)get_time())/1000000);
 
+    init_time();
     resrc_allocate_resources (resrcs, found_res, 1);
     resrc_allocate_resources (resrcs, found_res, 2);
     resrc_allocate_resources (resrcs, found_res, 3);
     resrc_reserve_resources (resrcs, found_res, 4);
     printf ("allocated\n");
-    resrc_print_resources (resrcs);
+    printf("allocate and reserve took: %lf\n", ((double)get_time())/1000000);
+    /* resrc_print_resources (resrcs); */
+    init_time();
     resrc_release_resources (resrcs, found_res, 1);
     printf ("released\n");
+    printf("release took: %lf\n", ((double)get_time())/1000000);
+    init_time();
     resrc_id_list_destroy (found_res);
-    resrc_print_resources (resrcs);
+    /* resrc_print_resources (resrcs); */
 
-    zhash_destroy (&resrcs);
+    resrc_destroy_resources (&resrcs);
+    printf("destroy took: %lf\n", ((double)get_time())/1000000);
 
     return 0;
 }

--- a/sched/schedsrv.h
+++ b/sched/schedsrv.h
@@ -14,6 +14,8 @@
 #include <stdint.h>
 #include <czmq.h>
 
+#include "resrc.h"
+
 
 /**
  *  Enumerates lightweight-job and resource events
@@ -78,7 +80,7 @@ typedef struct {
     lwj_state_e state;
     bool reserve;       /* reserve resources for job if true */
     flux_res_t *req;    /*!< resources requested by this LWJ */
-    zlist_t *resrc_ids; /*!< resources allocated to this LWJ */
+    resource_list_t *resrc_ids; /*!< resources allocated to this LWJ */
 } flux_lwj_t;
 
 


### PR DESCRIPTION
This adds an abstract structure type in place of the zlist and zhash members of the API.  The one exception to what I was thinking should be "outside" is the scheduling plugin implementing find and select.  Because of the way they are implemented, they seem to need to be behind the fence as well.

The SQLite module is based on this.
